### PR TITLE
Update download_wenetspeech.sh

### DIFF
--- a/utils/download_wenetspeech.sh
+++ b/utils/download_wenetspeech.sh
@@ -155,7 +155,7 @@ if [ $stage -le 3 ]; then
   echo "$0: Start to process the downloaded files(*.aes.tgz)"
   cp $download_dir/TERMS_OF_ACCESS $untar_dir
   if [ $modelscope == true ]; then
-    ms_download_dir=$download_dir/modelscope/hub/datasets/downloads/wenet/WenetSpeech/master
+    ms_download_dir=$download_dir/modelscope/hub/datasets/wenet/WenetSpeech/master
     for tgz in `ls $ms_download_dir | grep -v '\.'`; do
       process_downloaded_object ${ms_download_dir}/$tgz || exit 1;
     done || exit 1;


### PR DESCRIPTION
fix modelscope download dir.
$download_dir/modelscope/hub/datasets/downloads/wenet/WenetSpeech/master does not exist,
![image](https://github.com/wenet-e2e/WenetSpeech/assets/37294470/fb951677-2d3d-45b2-b6a4-eb409d5f4e51)
The correct path is $download_dir/modelscope/hub/datasets/wenet/WenetSpeech/master 
![image](https://github.com/wenet-e2e/WenetSpeech/assets/37294470/974f39c1-7792-44a4-9e37-15b7d2b33429)

